### PR TITLE
add support for PSK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
 **/*.rs.bk
 .idea
+.projectile
 

--- a/src/dtls_acceptor.rs
+++ b/src/dtls_acceptor.rs
@@ -1,5 +1,5 @@
 use crate::openssl::try_set_supported_protocols;
-use crate::{DtlsAcceptorBuilder, DtlsStream, HandshakeError, Identity, Protocol, Result};
+use crate::{DtlsAcceptorBuilder, DtlsStream, HandshakeError, CertificateIdentity, Protocol, Result};
 use openssl::ssl::{SslAcceptor, SslMethod};
 use std::{fmt, io, result};
 
@@ -11,7 +11,7 @@ impl DtlsAcceptor {
     /// Creates a `DtlsAcceptor` with default settings.
     ///
     /// The identity acts as the server's private key/certificate chain.
-    pub fn default(identity: Identity) -> Result<DtlsAcceptor> {
+    pub fn default(identity: CertificateIdentity) -> Result<DtlsAcceptor> {
         DtlsAcceptor::builder(identity).build()
     }
 
@@ -57,7 +57,7 @@ impl DtlsAcceptor {
     /// Returns a new builder for a `DtlsAcceptor`.
     ///
     /// The identity acts as the server's private key/certificate chain.
-    pub fn builder(identity: Identity) -> DtlsAcceptorBuilder {
+    pub fn builder(identity: CertificateIdentity) -> DtlsAcceptorBuilder {
         DtlsAcceptorBuilder {
             identity,
             srtp_profiles: vec![],

--- a/src/dtls_acceptor_builder.rs
+++ b/src/dtls_acceptor_builder.rs
@@ -1,4 +1,4 @@
-use crate::{DtlsAcceptor, Identity, Protocol, Result, SrtpProfile};
+use crate::{DtlsAcceptor, CertificateIdentity, Protocol, Result, SrtpProfile};
 
 /// A builder for `DtlsAcceptor`s.
 /// With this builder you can configure the following DTLS properties:
@@ -6,7 +6,7 @@ use crate::{DtlsAcceptor, Identity, Protocol, Result, SrtpProfile};
 /// - Adding and enabling the the DTLS extension 'use_srtp'
 /// - Configuring min/max supported DTLS versions
 pub struct DtlsAcceptorBuilder {
-    pub(crate) identity: Identity,
+    pub(crate) identity: CertificateIdentity,
     pub(crate) srtp_profiles: Vec<SrtpProfile>,
     pub(crate) min_protocol: Option<Protocol>,
     pub(crate) max_protocol: Option<Protocol>,

--- a/src/dtls_connection_builder.rs
+++ b/src/dtls_connection_builder.rs
@@ -1,6 +1,5 @@
-use bytes::Bytes;
-use crate::{Certificate, DtlsConnector, Identity, Protocol, Result, SrtpProfile};
-
+use crate::{Certificate, DtlsConnector, ConnectorIdentity, Protocol, Result, SrtpProfile};
+ 
 /// A builder for `DtlsConnector`s.
 ///
 /// With this builder you can configure the following DTLS properties:
@@ -11,8 +10,7 @@ use crate::{Certificate, DtlsConnector, Identity, Protocol, Result, SrtpProfile}
 /// - Allowing invalid hostnames/certs for the connection
 /// - Enabling Server Name Indication (SNI)
 pub struct DtlsConnectorBuilder {
-    pub(crate) identity: Option<Identity>,
-    pub(crate) psk_identity: Option<(Bytes, Bytes)>,
+    pub(crate) identity: Option<ConnectorIdentity>,
     pub(crate) srtp_profiles: Vec<SrtpProfile>,
     pub(crate) min_protocol: Option<Protocol>,
     pub(crate) max_protocol: Option<Protocol>,
@@ -25,21 +23,8 @@ pub struct DtlsConnectorBuilder {
 
 impl DtlsConnectorBuilder {
     /// Sets the identity to be used for client certificate authentication.
-    pub fn identity(&mut self, identity: Identity) -> &mut DtlsConnectorBuilder {
+    pub fn identity(&mut self, identity: ConnectorIdentity) -> &mut DtlsConnectorBuilder {
         self.identity = Some(identity);
-        self.psk_identity = None;
-        self
-    }
-
-    /// Sets identity/key for client PSK authentication.
-    ///
-    /// Defaults to None
-    ///
-    /// # Hint
-    /// You should specify one of the PSK_* ciphers, i.e. PSK-AES128-CCM8
-    pub fn psk_identity(&mut self, identity: &[u8], psk: &[u8]) -> &mut DtlsConnectorBuilder {
-        self.psk_identity = Some((Bytes::from(identity), Bytes::from(psk)));
-        self.identity = None;
         self
     }
 

--- a/src/dtls_connector.rs
+++ b/src/dtls_connector.rs
@@ -1,6 +1,6 @@
 use crate::{
     openssl::{init_trust, try_set_supported_protocols},
-    DtlsConnectorBuilder, DtlsStream, Error, HandshakeError, Protocol,
+    DtlsConnectorBuilder, DtlsStream, Error, HandshakeError, Protocol, ConnectorIdentity
 };
 use log::debug;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
@@ -42,31 +42,37 @@ impl DtlsConnector {
         }
 
         if let Some(ref identity) = builder.identity {
-            let identity = identity.as_ref();
+            match identity {
+                ConnectorIdentity::Certificate(identity) => {
+                    let identity = identity.as_ref();
 
-            connector.set_certificate(&identity.cert)?;
-            connector.set_private_key(&identity.pkey)?;
-            if let Some(ref chain) = identity.chain {
-                for cert in chain.iter().rev() {
-                    connector.add_extra_chain_cert(cert.to_owned())?;
+                    connector.set_certificate(&identity.cert)?;
+                    connector.set_private_key(&identity.pkey)?;
+                    if let Some(ref chain) = identity.chain {
+                        for cert in chain.iter().rev() {
+                            connector.add_extra_chain_cert(cert.to_owned())?;
+                        }
+                    }
+                },
+
+                ConnectorIdentity::Psk(identity_) => {
+                    let identity_ = identity_.clone();
+
+                    connector.set_psk_client_callback(move |_, _, mut identity, mut psk| {
+                        if let Err(err) = identity.write_all(&identity_.0) {
+                            debug!("psk_client_callback error (identity): {:?}", err);
+                            return Err(ErrorStack::get());
+                        }
+
+                        if let Err(err) =  psk.write_all(&identity_.1) {
+                            debug!("psk_client_callback error (psk): {:?}", err);
+                            return Err(ErrorStack::get());
+                        }
+
+                        Ok(identity_.1.len())
+                    });
                 }
             }
-        }
-
-        if let Some((identity_, psk_)) = builder.psk_identity.clone() {
-            connector.set_psk_client_callback(move |_, _, mut identity, mut psk| {
-                if let Err(err) = identity.write_all(&identity_) {
-                    debug!("psk_client_callback error (identity): {:?}", err);
-                    return Err(ErrorStack::get());
-                }
-
-                if let Err(err) =  psk.write_all(&psk_) {
-                    debug!("psk_client_callback error (psk): {:?}", err);
-                    return Err(ErrorStack::get());
-                }
-
-                Ok(psk_.len())
-            });
         }
 
         if !builder.cipher_list.is_empty() {
@@ -93,7 +99,6 @@ impl DtlsConnector {
     pub fn builder() -> DtlsConnectorBuilder {
         DtlsConnectorBuilder {
             identity: None,
-            psk_identity: None,
             srtp_profiles: vec![],
             min_protocol: Some(Protocol::Dtlsv10),
             max_protocol: None,

--- a/src/dtls_connector.rs
+++ b/src/dtls_connector.rs
@@ -54,7 +54,6 @@ impl DtlsConnector {
                         }
                     }
                 },
-
                 ConnectorIdentity::Psk(identity_) => {
                     let identity_ = identity_.clone();
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,13 +1,15 @@
 use crate::{Certificate, Error};
 use openssl::pkcs12::{ParsedPkcs12, Pkcs12};
 
+use bytes::Bytes;
+
 /// A cryptographic identity.
 ///
 /// An identity is an X509 certificate along with its corresponding private key and chain of certificates to a trusted
 /// root.
-pub struct Identity(ParsedPkcs12);
+pub struct CertificateIdentity(ParsedPkcs12);
 
-impl Identity {
+impl CertificateIdentity {
     /// Parses a DER-formatted PKCS #12 archive, using the specified password to decrypt the key.
     ///
     /// The archive should contain a leaf certificate and its private key, as well any intermediate
@@ -20,10 +22,10 @@ impl Identity {
     /// ```bash
     /// openssl pkcs12 -export -out identity.pfx -inkey key.pem -in cert.pem -certfile chain_certs.pem
     /// ```
-    pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<Identity, Error> {
+    pub fn from_pkcs12(buf: &[u8], pass: &str) -> Result<CertificateIdentity, Error> {
         let pkcs12 = Pkcs12::from_der(buf)?;
         let parsed = pkcs12.parse(pass)?;
-        Ok(Identity(parsed))
+        Ok(CertificateIdentity(parsed))
     }
 
     /// Returns the X509 certificate from this identity.
@@ -32,14 +34,34 @@ impl Identity {
     }
 }
 
-impl From<ParsedPkcs12> for Identity {
+impl From<ParsedPkcs12> for CertificateIdentity {
     fn from(pkcs_12: ParsedPkcs12) -> Self {
-        Identity(pkcs_12)
+        CertificateIdentity(pkcs_12)
     }
 }
 
-impl AsRef<ParsedPkcs12> for Identity {
+impl AsRef<ParsedPkcs12> for CertificateIdentity {
     fn as_ref(&self) -> &ParsedPkcs12 {
         &self.0
     }
+}
+
+/// Identity/key for client PSK authentication.
+///
+/// Defaults to None
+///
+/// # Hint
+/// You should specify one of the PSK_* ciphers, i.e. PSK-AES128-CCM8
+#[derive(Clone)]
+pub struct PskIdentity(pub(crate) Bytes, pub(crate) Bytes);
+
+impl PskIdentity {
+    pub fn new(identity: &[u8], key: &[u8]) -> PskIdentity {
+        PskIdentity(Bytes::from(identity), Bytes::from(key))
+    }
+}
+/// Possible identities for DTLS connector (client)
+pub enum ConnectorIdentity {
+    Certificate(CertificateIdentity),
+    Psk(PskIdentity)
 }

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -60,6 +60,7 @@ impl PskIdentity {
         PskIdentity(Bytes::from(identity), Bytes::from(key))
     }
 }
+
 /// Possible identities for DTLS connector (client)
 pub enum ConnectorIdentity {
     Certificate(CertificateIdentity),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub use self::dtls_connection_builder::DtlsConnectorBuilder;
 pub use self::dtls_connector::DtlsConnector;
 pub use self::dtls_stream::DtlsStream;
 pub use self::error::{Error, HandshakeError, Result, SrtpProfileError};
-pub use self::identity::Identity;
+pub use self::identity::{ConnectorIdentity, CertificateIdentity, PskIdentity};
 pub use self::midhandshake_dtls_steam::MidHandshakeDtlsStream;
 pub use self::protocol::Protocol;
 pub use self::srtp_profile::SrtpProfile;


### PR DESCRIPTION
Some devices (i.e., Ikea TRADFRI) work with pre-shared keys (PSK) only. This patch adds support for PSK.